### PR TITLE
Bug fix with TRA export when divisions happen.

### DIFF
--- a/src/main/java/com/indago/tr2d/pg/Tr2dTrackingProblem.java
+++ b/src/main/java/com/indago/tr2d/pg/Tr2dTrackingProblem.java
@@ -499,7 +499,7 @@ public class Tr2dTrackingProblem implements TrackingProblem {
 					for ( final SegmentNode segmentNode : t.getSegments() ) {
 						if ( pgAssignment.getAssignment( segmentNode ) == 1 ) {
 							final NodeId key = nodeId( segmentNode );
-							solutionWriter.write( String.format( "H %3d %4d\n", t.getTime(), key.id() ) );
+							solutionWriter.write( String.format( "H %4d\n", key.id() ) );
 						}
 					}
 				}

--- a/src/main/java/com/indago/tr2d/ui/util/TraSolutionExporter.java
+++ b/src/main/java/com/indago/tr2d/ui/util/TraSolutionExporter.java
@@ -165,16 +165,17 @@ public class TraSolutionExporter {
 			for ( final DivisionHypothesis div : segVar.getOutAssignments().getDivisions() ) {
 				if ( solution.getAssignment( div ) == 1 ) {
 					trackletInfo.get( curId ).setEnd( time );
+					int parentId = curId;
 
 					curId++;
 					TraLineData child = new TraLineData( curId, time + 1 );
-					child.setParentId( curId - 1 );
+					child.setParentId( parentId );
 					trackletInfo.put( curId, child );
 					curId = collectLineageData( imgSolution, solution, time + 1, div.getDest1(), curId );
 
 					curId++;
 					child = new TraLineData( curId, time + 1 );
-					child.setParentId( curId - 2 );
+					child.setParentId( parentId );
 					trackletInfo.put( curId, child );
 					curId = collectLineageData( imgSolution, solution, time + 1, div.getDest2(), curId );
 				}


### PR DESCRIPTION
Bug fix with TRA export when divisions happen. It is possible that the two daughter cells do not have consecutive labels and in those cases, the setting of parent id was done wrongly. Introduced a new variable to store parent id. This should fix the bug
